### PR TITLE
Flush the file after each auto log line, to prevent partial lines on disk

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -893,7 +893,10 @@ begin
         CapacityEBC := FCurrentCapacity[caEBC];
         CapacityLocal := FCurrentCapacity[caLocal];
         if fLogFileIsOpen then
+        begin
           SaveCSVLine(FLogFile, TSec{vTime}, FLastI, FLastU, FCurrentCapacity[caEBC], FCurrentCapacity[caLocal]);
+          Flush(FLogFile);
+        end;
       end;
       lsVoltage.AddXY(T, FLastU);
       lsInvisibleVoltage.AddXY(0, Round1V(FLastU));


### PR DESCRIPTION
Thanks for your work on this, it works great. Big improvement over the program ZKETech supplies!

We have a scraper script that reads the CSVs periodically while the EBC is running, and I noticed that often the file ends with an incomplete line. I believe that WriteLn is buffering by number of bytes rather than by line, so sometimes it ends up flushing half way through writing a line. I fixed it by flushing after each SaveCSVLine in auto log mode.